### PR TITLE
Ignore Invalid Files in parsed child HTML elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv
 temp
 data.json
 data.json.bak
+.gitattributes
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -94,4 +95,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Output files
+NTU/
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ venv
 temp
 data.json
 data.json.bak
-.gitattributes
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -95,7 +94,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# Output files
-NTU/
 ```

--- a/ntu_learn_downloader/parsing.py
+++ b/ntu_learn_downloader/parsing.py
@@ -5,6 +5,7 @@ from typing import List, Union
 from ntu_learn_downloader.utils import is_download_link
 from ntu_learn_downloader.constants import GET_CONTENT_LIST_URL
 
+
 def parse_recorded_lecture_contents(html: str) -> str:
     m1 = re.search(r'var gsUserId\s+= "(\S+)";', html)
     m2 = re.search(r'var gsModuleId\s+= "(\S+)";', html)
@@ -14,9 +15,11 @@ def parse_recorded_lecture_contents(html: str) -> str:
         raise ValueError('Unable to get mp4 download link')
     gsUserId, gsModuleId = m1.groups()[0], m2.groups()[0]
     domain = m3.groups()[0]
-    url = "https://" + domain + "/content/" + gsUserId + "/" + gsModuleId + "/media/1.mp4"
+    url = "https://" + domain + "/content/" + \
+        gsUserId + "/" + gsModuleId + "/media/1.mp4"
 
     return url
+
 
 def parse_content_page(soup) -> List[Union[SDoc, SFolder, SLecture]]:
     # NOTE e.g. "course_id": "_306327_1", "content_id": "_1790226_1"
@@ -42,7 +45,7 @@ def parse_content_page(soup) -> List[Union[SDoc, SFolder, SLecture]]:
 
     def is_file(child, img):
         return img is not None and img.get("alt") == "File"
-    
+
     for c in children:
         img = c.find("img")
         if is_content_folder(c, img):
@@ -50,7 +53,8 @@ def parse_content_page(soup) -> List[Union[SDoc, SFolder, SLecture]]:
             name = hyperlink.text
             link = hyperlink.get("href")
             details = c.find("div", {"class": "details"}).text
-            result.append(SFolder(name.strip(), link.strip(), details.strip(), None))
+            result.append(
+                SFolder(name.strip(), link.strip(), details.strip(), None))
         elif is_item(c, img):
             folder = __item_to_folder(c)
             if folder:
@@ -62,10 +66,15 @@ def parse_content_page(soup) -> List[Union[SDoc, SFolder, SLecture]]:
             link = hyperlink.get("href")
             result.append(SLecture(name.strip(), link))
         elif is_file(c, img):
-            hyperlink = c.find("a")
-            name = hyperlink.text
-            link = hyperlink.get("href")
-            result.append(SDoc(name.strip(), link))
+            print("hello worldddd")
+            print(c)
+            try:
+                hyperlink = c.find("a")
+                name = hyperlink.text
+                link = hyperlink.get("href")
+                result.append(SDoc(name.strip(), link))
+            except:
+                pass
         else:
             pass
 
@@ -76,7 +85,8 @@ def __item_to_folder(item):
     folder_name = item.find("h3").text
     details = item.find("div", {"class", "details"})
 
-    dl_links = [a for a in details.find_all("a") if is_download_link(a.get("href"))]
+    dl_links = [a for a in details.find_all(
+        "a") if is_download_link(a.get("href"))]
     children = []
     for a_tag in dl_links:
         link, name = a_tag.get("href"), a_tag.text

--- a/ntu_learn_downloader/parsing.py
+++ b/ntu_learn_downloader/parsing.py
@@ -5,7 +5,6 @@ from typing import List, Union
 from ntu_learn_downloader.utils import is_download_link
 from ntu_learn_downloader.constants import GET_CONTENT_LIST_URL
 
-
 def parse_recorded_lecture_contents(html: str) -> str:
     m1 = re.search(r'var gsUserId\s+= "(\S+)";', html)
     m2 = re.search(r'var gsModuleId\s+= "(\S+)";', html)
@@ -15,11 +14,9 @@ def parse_recorded_lecture_contents(html: str) -> str:
         raise ValueError('Unable to get mp4 download link')
     gsUserId, gsModuleId = m1.groups()[0], m2.groups()[0]
     domain = m3.groups()[0]
-    url = "https://" + domain + "/content/" + \
-        gsUserId + "/" + gsModuleId + "/media/1.mp4"
+    url = "https://" + domain + "/content/" + gsUserId + "/" + gsModuleId + "/media/1.mp4"
 
     return url
-
 
 def parse_content_page(soup) -> List[Union[SDoc, SFolder, SLecture]]:
     # NOTE e.g. "course_id": "_306327_1", "content_id": "_1790226_1"
@@ -45,7 +42,7 @@ def parse_content_page(soup) -> List[Union[SDoc, SFolder, SLecture]]:
 
     def is_file(child, img):
         return img is not None and img.get("alt") == "File"
-
+    
     for c in children:
         img = c.find("img")
         if is_content_folder(c, img):
@@ -53,8 +50,7 @@ def parse_content_page(soup) -> List[Union[SDoc, SFolder, SLecture]]:
             name = hyperlink.text
             link = hyperlink.get("href")
             details = c.find("div", {"class": "details"}).text
-            result.append(
-                SFolder(name.strip(), link.strip(), details.strip(), None))
+            result.append(SFolder(name.strip(), link.strip(), details.strip(), None))
         elif is_item(c, img):
             folder = __item_to_folder(c)
             if folder:
@@ -66,9 +62,7 @@ def parse_content_page(soup) -> List[Union[SDoc, SFolder, SLecture]]:
             link = hyperlink.get("href")
             result.append(SLecture(name.strip(), link))
         elif is_file(c, img):
-            print("hello worldddd")
-            print(c)
-            try:
+            try :
                 hyperlink = c.find("a")
                 name = hyperlink.text
                 link = hyperlink.get("href")
@@ -85,8 +79,7 @@ def __item_to_folder(item):
     folder_name = item.find("h3").text
     details = item.find("div", {"class", "details"})
 
-    dl_links = [a for a in details.find_all(
-        "a") if is_download_link(a.get("href"))]
+    dl_links = [a for a in details.find_all("a") if is_download_link(a.get("href"))]
     children = []
     for a_tag in dl_links:
         link, name = a_tag.get("href"), a_tag.text


### PR DESCRIPTION
This PR resolves #8, by ignoring parsed child HTML elements, if they do not contain an expected `<a>` tag anchor link.